### PR TITLE
Revert "Searches now return tweet objects again instead of content strings."

### DIFF
--- a/Sources/WebApi/hippo_web/api.py
+++ b/Sources/WebApi/hippo_web/api.py
@@ -47,7 +47,7 @@ def search(terms):
     results=s.execute()
 
     for hit in results:
-        result_tweets.append(hit)
+        result_tweets.append(hit.content)
 
     return jsonify(result_tweets)
 


### PR DESCRIPTION
Reverts RUGSoftEng/2018-Hippo#48